### PR TITLE
Fix API calls and sync

### DIFF
--- a/beetime/api.py
+++ b/beetime/api.py
@@ -26,7 +26,7 @@ def apiCall(method, user, token, slug, data, did):
     """
 
     cmd = "datapoints"
-    base = f"http://www.beeminder.com/api/v1/users/{user}/goals/{slug}"
+    base = f"https://www.beeminder.com/api/v1/users/{user}/goals/{slug}/"
     if method == "POST" and did is not None:
         url = urljoin(base, f"{cmd}/{did}.json")
         method = "PUT"

--- a/beetime/sync.py
+++ b/beetime/sync.py
@@ -4,7 +4,7 @@ import time
 from aqt import mw, progress
 
 from beetime.api import getApi, sendApi
-from beetime.lookup import lookupReviewed, formatComment, lookupAdded
+from beetime.lookup import lookupReviewed, formatComment, lookupAdded, getDataPointId
 from beetime.util import getDayStamp
 from beetime.settings import BEE
 


### PR DESCRIPTION
Thank you for porting this addon to Anki 2.1!

It did not work for me with the latest Anki versions on Mac (2.1.15 or later), but just a couple of simple fixes did the trick. As other people might want to use your fork with Anki 2.1+, please consider merging this. :)